### PR TITLE
追加

### DIFF
--- a/zukan_create_frontend/src/components/AddField.jsx
+++ b/zukan_create_frontend/src/components/AddField.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Draggable from './interactjs/Draggable';
 import Resizable from './interactjs/Resizable';
 
-const AddField = ({ data, onUpdatePosition, onUpdateSize }) => {
+const AddField = ({ data, onUpdatePosition, onUpdateSize, onFieldContent }) => {
   Draggable('.field-card', onUpdatePosition);
   Resizable('.field-card-text', onUpdateSize);
 
@@ -16,6 +16,8 @@ const AddField = ({ data, onUpdatePosition, onUpdateSize }) => {
               <textarea
                 type="text"
                 className='field-card-text'
+                value={fieldDesign.value}
+                onChange={(e) => onFieldContent(fieldDesign.uuid, e.target.value)}
                 style={{
                   backgroundColor: fieldDesign.attributes.backgroundColor,
                   color: fieldDesign.attributes.color,

--- a/zukan_create_frontend/src/components/AddTemplate.jsx
+++ b/zukan_create_frontend/src/components/AddTemplate.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import Draggable from './interactjs/Draggable';
 import Resizable from './interactjs/Resizable';
 
-function AddTemplate({ templateData, onUpdatePosition, onUpdateSize }) {
+function AddTemplate({ templateData, onUpdatePosition, onUpdateSize, onFieldContent }) {
   Draggable('.field-card', onUpdatePosition);
   Resizable('.field-card-text', onUpdateSize);
   const [inputs, setInputs] = useState([]);
@@ -39,6 +39,8 @@ function AddTemplate({ templateData, onUpdatePosition, onUpdateSize }) {
                 <textarea
                   type="text"
                   className='field-card-text'
+                  value={input.value}
+                  onChange={(e) => onFieldContent(input.uuid, e.target.value)}  
                   style={{
                     backgroundColor: input.backgroundColor,
                     color: input.color,

--- a/zukan_create_frontend/src/components/CreateIllustratedBook.jsx
+++ b/zukan_create_frontend/src/components/CreateIllustratedBook.jsx
@@ -21,7 +21,7 @@ export const CreateIllustratedBook = () => {
     const uuid = uuidv4();
     setInputs((prevInputs) => [
       ...prevInputs,
-      { ...inputData, x: 0, y: 0, width: null, height: null, uuid: uuid},
+      { ...inputData, x: 0, y: 0, width: null, height: null, uuid: uuid },
     ]);
   };
 
@@ -51,6 +51,18 @@ export const CreateIllustratedBook = () => {
     });
   };
 
+  const onFieldContent = (uuid, value) => {
+    console.log(uuid, value)
+    setInputs((prevInputs) => {
+      return prevInputs.map((input) => {
+        if (input.uuid === uuid) {
+          return { ...input, content: value };
+        }
+        return input;
+      });
+    });
+  };
+
   useEffect(() => {
     const fetchTags = async () => {
       try {
@@ -71,10 +83,6 @@ export const CreateIllustratedBook = () => {
     history("/mypage");
   };
 
-  const generateParams = {
-    title: title,
-    tags: tagStr,
-  };
 
   const handleChange = (e) => {
     setTitle(e.target.value);
@@ -93,18 +101,33 @@ export const CreateIllustratedBook = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const params = {
-        ...generateParams,
-        ...(template && { templateId: template.id }),
+      const generateParams = {
+        tags: tagStr,
+        illustrated_book: {
+        title: title,
+        template_id: template.id,
+        illustrated_book_field_designs_attributes: inputs.map(input => ({
+          field_design_id: input.id,
+          content: input.content,
+        }))
+        }
       };
-      const response = await client.post('/user/illustrated_books', params);
+
+      const response = await client.post('/user/illustrated_books', generateParams);
       setTitle("");
       setTags([]);
+      setInputs([]);
       history("/mypage");
     } catch (error) {
       console.log(error);
     }
   };
+
+  useEffect(() => {
+    console.log(template.id)
+  },[template])
+
+
 
   return (
     <div className='container'>
@@ -118,8 +141,8 @@ export const CreateIllustratedBook = () => {
             value={title}
           />
           <div className="draggable-area" style={{backgroundColor: 'white', width: '210mm', height: '297mm', position: 'relative'}}>
-            <AddTemplate templateData={template} onUpdatePosition={updateInputPosition} onUpdateSize={updateInputSize} />
-            <AddField data={inputs} onUpdatePosition={updateInputPosition} onUpdateSize={updateInputSize}/>
+            <AddTemplate templateData={template} onFieldContent={onFieldContent} onUpdatePosition={updateInputPosition} onUpdateSize={updateInputSize} />
+            <AddField data={inputs} onFieldContent={onFieldContent} onUpdatePosition={updateInputPosition} onUpdateSize={updateInputSize}/>
           </div>
           <ReactTags
             placeholder="Enterでタグ追加"

--- a/zukan_create_frontend/src/components/modal/Templates.jsx
+++ b/zukan_create_frontend/src/components/modal/Templates.jsx
@@ -25,7 +25,6 @@ function Templates({ onAddTemplate }) {
         const fieldDesignObjects = fieldDesignsCount.map(relationship => {
           return includedFieldDesigns.find(included => included.id === relationship.id);
         });
-
         onAddTemplate({
           id: templateId,
           templateFieldDesigns: templateFieldDesignObjects, 


### PR DESCRIPTION
CreateIllustratedBook：
textareaの入力内容をパラメーターに含める
入力内容をcontentsとして変数inputs内に代入
子コンポーネントからonFieldContentをpropsとして受け取り
AddTemplate:
親コンポーネントにtextareaのuuidとcontentを送信
AddField：
親コンポーネントにtextareaのuuidとcontentを送信

残タスク
AddTemplateのtextareaにはuuidが無いので含ませる
illustrated_book作成時の500エラーの解消